### PR TITLE
fix: deprecated `django.conf.urls.url` in django 4.0

### DIFF
--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -1,20 +1,19 @@
 """
 sandbox URLs
 """
-from django.conf.urls import url
 from django.contrib import admin
-from django.urls import path, reverse_lazy
+from django.urls import path, re_path, reverse_lazy
 from django.views.generic import RedirectView
 
 from views import LaunchURLWithAuth, SimpleLaunchURLVerification, demo_consumer
 
 urlpatterns = [
     # / Redirects to the demo consumer
-    url(
+    re_path(
         r"^$", RedirectView.as_view(url=reverse_lazy("demo_consumer"), permanent=False),
     ),
     # Demo LTI consumer
-    url(r"^consumer$", demo_consumer, name="demo_consumer"),
+    re_path(r"^consumer$", demo_consumer, name="demo_consumer"),
     # Simple LTI launch request verification
     path(
         "lti/launch-verification",


### PR DESCRIPTION
`django.conf.urls.url()` is removed in django 4.0 in favour of
`django.urls.re_path`.

See:
https://docs.djangoproject.com/en/3.2/ref/urls/#url
https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0