### PR TITLE
🏗️(lti_toolbox) accept deep linking LTI request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Accept Content-Item selection request used in a deep linking context
+- Add an LTIMessageType enum
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Accept Content-Item selection request used in a deep linking context
+
 ### Fixed
 
 - Use modern python method decorator for all LTI view classes

--- a/sandbox/forms.py
+++ b/sandbox/forms.py
@@ -7,7 +7,7 @@ from lti_toolbox.models import LTIPassport
 
 
 class PassportChoiceField(forms.ModelChoiceField):
-    """Select a LTI password"""
+    """Select an LTI password"""
 
     def label_from_instance(self, obj):
         return f"{obj.consumer.slug} - {obj.title}"

--- a/sandbox/views.py
+++ b/sandbox/views.py
@@ -20,7 +20,7 @@ from forms import LTIConsumerForm
 class SimpleLaunchURLVerification(BaseLTIView):
     """Example view to handle LTI launch request verification."""
 
-    def _do_on_success(self, lti_request: LTI) -> HttpResponse:
+    def _do_on_success(self, lti_request: LTI, *args, **kwargs) -> HttpResponse:
         # Render a template with some debugging information
         context = {
             "message": "LTI request verified successfully",

--- a/src/lti_toolbox/backend.py
+++ b/src/lti_toolbox/backend.py
@@ -24,7 +24,7 @@ class LTIBackend(ModelBackend):
 
     def authenticate(self, request, username=None, password=None, **kwargs):
         """
-        Authenticate a user from a LTI request
+        Authenticate a user from an LTI request
 
         Args:
             request: django http request
@@ -62,7 +62,7 @@ class LTIBackend(ModelBackend):
 
     @staticmethod
     def _get_mandatory_param(lti_request: LTI, param: str) -> Any:
-        """Get a LTI parameter or throw a exception if not defined."
+        """Get an LTI parameter or throw a exception if not defined."
 
         Args:
             lti_request: The verified LTI request

--- a/src/lti_toolbox/exceptions.py
+++ b/src/lti_toolbox/exceptions.py
@@ -7,7 +7,7 @@ class LTIException(Exception):
 
 class LTIRequestNotVerifiedException(LTIException):
     """
-    Custom LTI exception thrown when someone try to access
+    Custom LTI exception thrown when someone tries to access
     LTI parameters before verifying the request.
     """
 

--- a/src/lti_toolbox/exceptions.py
+++ b/src/lti_toolbox/exceptions.py
@@ -16,24 +16,24 @@ class LTIRequestNotVerifiedException(LTIException):
         super().__init__(message)
 
 
-class LaunchParamException(Exception):
-    """Custom Exception related to LTI launch param processing."""
+class ParamException(Exception):
+    """Custom Exception related to LTI param processing."""
 
 
-class InvalidLaunchParamException(LaunchParamException):
-    """Custom Exception thrown when an invalid parameter is found in a LTI launch request."""
+class InvalidParamException(ParamException):
+    """Custom Exception thrown when an invalid parameter is found in an LTI request."""
 
     def __init__(self, param):
-        message = f"{param:s} is not a valid launch param"
+        message = f"{param:s} is not a valid param"
         super().__init__(message)
 
 
-class MissingLaunchParamException(LaunchParamException):
+class MissingParamException(ParamException):
     """
     Custom Exception thrown when a required LTI parameter is missing in
-    an LTI launch request.
+    an LTI request.
     """
 
     def __init__(self, param):
-        message = f"missing launch param : {param:s}"
+        message = f"missing param : {param:s}"
         super().__init__(message)

--- a/src/lti_toolbox/launch_params.py
+++ b/src/lti_toolbox/launch_params.py
@@ -4,13 +4,22 @@ Utilities to represent and validate LTI Launch parameters
 This is based on lti library (https://github.com/pylti/lti).
 """
 from collections.abc import MutableMapping
+from enum import Enum
 from typing import List, Set, Union
 from urllib.parse import urlencode
 
 from .exceptions import InvalidParamException, MissingParamException
 
 DEFAULT_LTI_VERSION = "LTI-1.0"
-SELECTION_PARAMS_MESSAGE_TYPE = "ContentItemSelectionRequest"
+
+
+class LTIMessageType(Enum):
+    """Enum describing all type of message received through LTI requests."""
+
+    LAUNCH_REQUEST = "basic-lti-launch-request"
+    SELECTION_REQUEST = "ContentItemSelectionRequest"
+    SELECTION_RESPONSE = "ContentItemSelection"
+
 
 LAUNCH_PARAMS_REQUIRED = {"lti_message_type", "lti_version", "resource_link_id"}
 

--- a/src/lti_toolbox/launch_params.py
+++ b/src/lti_toolbox/launch_params.py
@@ -163,7 +163,7 @@ class ParamsMixins(MutableMapping):
                 raise MissingParamException(param)
 
     def _param_value(self, param: str) -> Union[str, List]:
-        """Get the value of a LTI parameter.
+        """Get the value of an LTI parameter.
 
         Args:
             param: LTI parameter name
@@ -176,7 +176,7 @@ class ParamsMixins(MutableMapping):
         return self._params[param]
 
     def valid_param(self, param: str) -> bool:
-        """Checks if a LTI parameter is valid or not.
+        """Checks if an LTI parameter is valid or not.
 
         Args:
             param: LTI parameter name

--- a/src/lti_toolbox/lti.py
+++ b/src/lti_toolbox/lti.py
@@ -89,7 +89,7 @@ class LTI:
         return self._verified and self._valid
 
     def get_param(self, name: str, default: Any = None):
-        """Retrieve a LTI parameter value given its name.
+        """Retrieve an LTI parameter value given its name.
 
         Args:
             name: Name of the LTI parameter

--- a/src/lti_toolbox/lti.py
+++ b/src/lti_toolbox/lti.py
@@ -6,12 +6,7 @@ from typing import Any, Optional
 from oauthlib.oauth1 import SignatureOnlyEndpoint
 
 from .exceptions import LTIException, LTIRequestNotVerifiedException, ParamException
-from .launch_params import (
-    SELECTION_PARAMS_MESSAGE_TYPE,
-    LaunchParams,
-    ParamsMixins,
-    SelectionParams,
-)
+from .launch_params import LaunchParams, LTIMessageType, ParamsMixins, SelectionParams
 from .models import LTIConsumer, LTIPassport
 from .validator import LTIRequestValidator
 
@@ -37,8 +32,8 @@ class LTI:
     def _process_params(self) -> ParamsMixins:
         """Process LTI parameters based on request type."""
         is_selection_request = (
-                self.request.POST.get("lti_message_type")
-                == SELECTION_PARAMS_MESSAGE_TYPE
+            self.request.POST.get("lti_message_type")
+            == LTIMessageType.SELECTION_REQUEST.value
         )
         try:
             params = (

--- a/src/lti_toolbox/models.py
+++ b/src/lti_toolbox/models.py
@@ -129,5 +129,5 @@ class LTIPassport(models.Model):
     def generate_shared_secret() -> str:
         """Generate a random consumer key."""
         secret_chars = string.ascii_letters + string.digits + "!#$%&*+-=?@^_"
-        secret_size = secret_size = secrets.choice(range(40, 60))
+        secret_size = secrets.choice(range(40, 60))
         return "".join(secrets.choice(secret_chars) for _ in range(secret_size))

--- a/src/lti_toolbox/models.py
+++ b/src/lti_toolbox/models.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 
 class LTIConsumer(models.Model):
     """
-    Model representing a LTI Consumer.
+    Model representing an LTI Consumer.
     """
 
     slug = models.SlugField(
@@ -48,7 +48,7 @@ class LTIPassport(models.Model):
     """
     Model representing an LTI passport for LTI consumers to interact with the django application.
 
-    A LTI consumer can have multiple passports.
+    An LTI consumer can have multiple passports.
 
     An LTI passport stores credentials that can be used by an LTI consumer to interact with
     the django application acting as an LTI provider.

--- a/src/lti_toolbox/validator.py
+++ b/src/lti_toolbox/validator.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 class LTIRequestValidator(RequestValidator):
     """
     This validator implements the RequestValidator from the oauthlib, but only with methods
-    required for a LTI launch request.
+    required for an LTI launch request.
     """
 
     LTI_REPLAY_PROTECTION_CACHE = "lti_replay"

--- a/src/lti_toolbox/views.py
+++ b/src/lti_toolbox/views.py
@@ -27,12 +27,12 @@ class BaseLTIView(ABC, View):
         lti_request = LTI(request)
         try:
             lti_request.verify()
-            return self._do_on_success(lti_request)
+            return self._do_on_success(lti_request, *args, **kwargs)
         except LTIException as error:
             return self._do_on_failure(request, error)
 
     @abstractmethod
-    def _do_on_success(self, lti_request: LTI) -> HttpResponse:
+    def _do_on_success(self, lti_request: LTI, *args, **kwargs) -> HttpResponse:
         """Process the request when the LTI requests is verified."""
         raise NotImplementedError()
 

--- a/src/lti_toolbox/views.py
+++ b/src/lti_toolbox/views.py
@@ -15,7 +15,7 @@ from .lti import LTI
 @method_decorator(csrf_exempt, name="dispatch")
 class BaseLTIView(ABC, View):
     """
-    Abstract view for handling views from an LTI Launch request.
+    Abstract view for handling views from an LTI request.
 
     This class verifies the authenticity of the incoming LTI requests.
     Subclasses must implement the _do_on_success() method to define custom
@@ -33,23 +33,23 @@ class BaseLTIView(ABC, View):
 
     @abstractmethod
     def _do_on_success(self, lti_request: LTI) -> HttpResponse:
-        """Process the request when the LTI launch requests is verified."""
+        """Process the request when the LTI requests is verified."""
         raise NotImplementedError()
 
     def _do_on_failure(  # pylint: disable=R0201
         self, request: HttpRequest, error: LTIException  # pylint: disable=W0613
     ) -> HttpResponse:
         """
-        Default handler for invalid LTI launch requests.
+        Default handler for invalid LTI requests.
         You are encouraged to define your own handler according to your project needs.
         """
-        return HttpResponseForbidden("Invalid LTI launch request")
+        return HttpResponseForbidden("Invalid LTI request")
 
 
 @method_decorator(csrf_exempt, name="dispatch")
 class BaseLTIAuthView(ABC, View):
     """
-    Abstract view for handling authenticated views from an LTI Launch request.
+    Abstract view for handling authenticated views from an LTI request.
 
     This class verifies the authenticity of the incoming LTI requests,
     and performs user authentication.
@@ -88,7 +88,7 @@ class BaseLTIAuthView(ABC, View):
         self, request: HttpRequest, error: LTIException  # pylint: disable=W0613
     ) -> HttpResponse:
         """
-        Default handler for invalid LTI launch requests.
+        Default handler for invalid LTI requests.
         You are encouraged to define your own handler according to your project needs.
         """
-        return HttpResponseForbidden("Invalid LTI launch request")
+        return HttpResponseForbidden("Invalid LTI request")

--- a/tests/lti_toolbox/test_launch_params.py
+++ b/tests/lti_toolbox/test_launch_params.py
@@ -128,7 +128,6 @@ class LaunchParamTestCase(TestCase):
             )
 
 
-
 class SelectionParamTestCase(TestCase):
     """Test the SelectionParam class"""
 
@@ -144,7 +143,7 @@ class SelectionParamTestCase(TestCase):
         url = "http://testserver/lti/launch"
         signed_parameters = sign_parameters(passport, lti_parameters, url)
         return SelectionParams(signed_parameters)
-    
+
     def test_only_required_parameters(self):
         """Test validation of a minimalistic LTI Content-Item
         Selection request with only required parameters.

--- a/tests/lti_toolbox/test_launch_params.py
+++ b/tests/lti_toolbox/test_launch_params.py
@@ -13,7 +13,7 @@ class LaunchParamTestCase(TestCase):
     """Test the LaunchParam class"""
 
     def setUp(self):
-        """Override the setUp method to instanciate and serve a request factory."""
+        """Override the setUp method to instantiate and serve a request factory."""
         super().setUp()
         self.request_factory = RequestFactory()
 
@@ -99,7 +99,7 @@ class LaunchParamTestCase(TestCase):
         )
 
     def test_urlencoded(self):
-        """Test urlencoded representation of a LTI launch request."""
+        """Test urlencoded representation of an LTI launch request."""
 
         launch_params = LaunchParams(
             {

--- a/tests/lti_toolbox/test_lti.py
+++ b/tests/lti_toolbox/test_lti.py
@@ -1,4 +1,4 @@
-"""Test the LTI interconnection with a LTI consumer."""
+"""Test the LTI interconnection with an LTI consumer."""
 from urllib.parse import urlencode
 
 from django.test import RequestFactory, TestCase
@@ -14,7 +14,7 @@ class LTITestCase(TestCase):
     """Test the LTI class"""
 
     def setUp(self):
-        """Override the setUp method to instanciate and serve a request factory."""
+        """Override the setUp method to instantiate and serve a request factory."""
         super().setUp()
         self.request_factory = RequestFactory()
         self._consumer = LTIConsumerFactory(slug="test_lti")

--- a/tests/lti_toolbox/utils.py
+++ b/tests/lti_toolbox/utils.py
@@ -12,7 +12,7 @@ def sign_parameters(passport, lti_parameters, url):
 
     Args:
         passport: The LTIPassport to use to sign the oauth request
-        lti_parameters: A dictionnary of parameters to sign
+        lti_parameters: A dictionary of parameters to sign
         url: The LTI launch URL
 
     Returns:


### PR DESCRIPTION
### Purpose

Enriched the LTI Toolbox capabilities, enabling Content-Item Selection requests, used in deep linking context.

Refined parameter handling, ensuring the LTI class adapts smoothly to varying request types, namely `Launch` or `Selection` ones.

Without these updates, LTI base views could not be used to handle deep linking. `Launch` and `Selection` requests don’t share the same required parameters. Please refer to the LTI documentation for this part.

Plus, some `Launch` parameters should not be passed while sending a `Selection` one.

### Proposition

- [X] Redesign parameter class
- [X] Adapt relevant documentation
- [x] Test the package locally
- [x] Update tests