### PR TITLE
✨(project) enhance the LTI class with origin_url and is_moodle_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Enhance the LTI class with `origin_url` and `is_moodle_format` properties
+
 ## [1.2.0] - 2023-09-13
 
 ### Added

--- a/bin/pytest
+++ b/bin/pytest
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+declare DOCKER_USER
+DOCKER_USER="$(id -u):$(id -g)"
+
+DOCKER_USER=${DOCKER_USER} docker compose run --rm django-lti-toolbox pytest "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   postgresql:
     image: postgres:12


### PR DESCRIPTION
## Purpose

To use django-lti-toolbox for LTI requests coming from a Moodle instance, we need some additionnal properties.

## Proposal

Added several properties:
- `origin_url`, recreating the URL that was used to launch the LTI request
- `is_moodle_format`, boolean indicating if the LTI request is from Moodle.


On a side note, removing the obsolete docker compose template version, and adding a `bin/pytest` helper to ease development.
