### PR TITLE
🐛(lti_toolbox) compute `origin_url` from consumer url instead of referer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Compute `origin_url` from consumer URL instead of `HTTP_REFERER`
+
 ## [1.3.0] - 2024-04-25
 
 ### Added

--- a/src/lti_toolbox/factories.py
+++ b/src/lti_toolbox/factories.py
@@ -1,4 +1,5 @@
 """Factories for the ``lti_toolbox``."""
+
 import factory
 from factory.django import DjangoModelFactory
 
@@ -14,7 +15,7 @@ class LTIConsumerFactory(DjangoModelFactory):
 
     slug = factory.Sequence(lambda n: f"consumer{n}")
     title = factory.Sequence(lambda n: f"Consumer {n}")
-    url = factory.Sequence(lambda n: f"https://www.example.com/consumer-{n}/")
+    url = factory.Sequence(lambda n: f"https://testserver/consumer-{n}")
 
 
 class LTIPassportFactory(DjangoModelFactory):

--- a/src/lti_toolbox/lti.py
+++ b/src/lti_toolbox/lti.py
@@ -1,5 +1,5 @@
-"""LTI module that supports LTI 1.0.
-"""
+"""LTI module that supports LTI 1.0."""
+
 import re
 from typing import Any, Optional, Set
 from urllib.parse import urljoin
@@ -143,16 +143,18 @@ class LTI:
     @property
     def origin_url(self):
         """Try to recreate the URL that was used to launch the LTI request."""
-        base_url = self.request.META.get("HTTP_REFERER")
+        base_url = self.get_consumer().url
         if not base_url:
             return None
+        if not base_url.endswith("/"):
+            base_url = f"{base_url}/"
         context_id = self.get_param("context_id")
 
         url = None
         if self.is_edx_format:
-            url = urljoin(base_url, f"/course/{context_id}")
+            url = urljoin(base_url, f"course/{context_id}")
         elif self.is_moodle_format:
-            url = urljoin(base_url, f"/course/view.php?id={context_id}")
+            url = urljoin(base_url, f"course/view.php?id={context_id}")
 
         return url
 

--- a/tests/lti_toolbox/test_lti.py
+++ b/tests/lti_toolbox/test_lti.py
@@ -1,4 +1,5 @@
 """Test the LTI interconnection with an LTI consumer."""
+
 from urllib.parse import urlencode
 
 from django.test import RequestFactory, TestCase
@@ -34,7 +35,6 @@ class LTITestCase(TestCase):
             url,
             data=urlencode(signed_parameters),
             content_type=CONTENT_TYPE,
-            HTTP_REFERER="http://testserver",
         )
         return LTI(request)
 
@@ -366,7 +366,7 @@ class LTITestCase(TestCase):
 
         self.assertEqual(
             lti.origin_url,
-            "http://testserver/course/course-v1:fooschool+mathematics+0042",
+            "https://testserver/consumer-20/course/course-v1:fooschool+mathematics+0042",
         )
 
     def test_lti_origin_url_moodle(self):
@@ -381,4 +381,6 @@ class LTITestCase(TestCase):
         }
         lti = self._verified_lti_request(lti_parameters)
 
-        self.assertEqual(lti.origin_url, "http://testserver/course/view.php?id=123")
+        self.assertEqual(
+            lti.origin_url, "https://testserver/consumer-21/course/view.php?id=123"
+        )


### PR DESCRIPTION
## Purpose

Due to LMS instances potentially behind proxies or under subpages, relying on `HTTP_REFERER` to compute the origin url is not feasible.

## Proposal

Instead, the consumer URL, provided via the LTI passport, can be used to compute the `origin_url`.
