### PR TITLE
⬆️(backend) update postgres to version 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
           DB_PASSWORD: pass
           DB_PORT: 5432
       # services
-      - image: circleci/postgres:13-ram
+      - image: cimg/postgres:16.4
         environment:
           POSTGRES_DB: lti_toolbox
           POSTGRES_USER: fun

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgresql:
-    image: postgres:13
+    image: postgres:16
     env_file:
       - env.d/development/postgresql
     ports:


### PR DESCRIPTION
## Purpose

As we want to update our postgres server to version 16, we use it locally and in our CI as well.